### PR TITLE
Fix typo.

### DIFF
--- a/sensu/files/conf.d/checks/changes_zookeeper_running.json
+++ b/sensu/files/conf.d/checks/changes_zookeeper_running.json
@@ -1,7 +1,7 @@
 {
   "checks": {
     "changes_zookeeper_running": {
-      "command": "check-procs.rb -p -p '^java .* org.apache.zookeeper.server.quorum.QuorumPeerMain' -e 30 -C 1",
+      "command": "check-procs.rb -p '^java .* org.apache.zookeeper.server.quorum.QuorumPeerMain' -e 30 -C 1",
       "subscribers": [
         "changes_zookeeper"
       ],


### PR DESCRIPTION
There's an extra `-p` in the arg list for the zookeeper check it causes it find anything with `-p` instead of the zookeeper main class name.

/cc @kklipsch 